### PR TITLE
solve issue of low contrast

### DIFF
--- a/app/src/main/res/layout-sw600dp/recycler_view_item.xml
+++ b/app/src/main/res/layout-sw600dp/recycler_view_item.xml
@@ -28,6 +28,7 @@
         android:textAlignment="center"
         android:textAllCaps="false"
         android:textSize="16sp"
+        android:textColor="#626262"
         android:textStyle="bold" />
 
 </android.support.v7.widget.CardView>

--- a/app/src/main/res/layout-sw720dp/recycler_view_item.xml
+++ b/app/src/main/res/layout-sw720dp/recycler_view_item.xml
@@ -28,6 +28,7 @@
         android:textAlignment="center"
         android:textAllCaps="false"
         android:textSize="18sp"
+        android:textColor="#626262"
         android:textStyle="bold" />
 
 </android.support.v7.widget.CardView>


### PR DESCRIPTION
The original text color of the component is '#686868', and the contrast between the text color ('#686868') and the background color ('#E2E2E2') does not meet the standard of WCAG 2.1. In other words, this color cannot be easily seen by everyone. So, to solve this problem, our team designed a tool that can automatically detect and repair such problems. The test report and recommended replacement colors ('#626262') are as follows:
![image](https://user-images.githubusercontent.com/101503193/184936309-94839a54-12f5-4129-8abd-841b574cfd2c.png)
The figure on the left is the original page, the figure on the right is the repaired page, and the figure below is the problem detection report.
If you think it is useful, please give me feedback. Your feedback is very important to me. We sincerely hope to receive your suggestions and opinions as an app developer.